### PR TITLE
Use Node v20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: yarn install --frozen-lockfile --non-interactive
@@ -36,19 +36,19 @@ jobs:
 
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Extract
       id: extract
       run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
     - name: Checkout pre-built
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: release-${{ steps.extract.outputs.branch }}
         path: prebuilt

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Since there is no need to commit `node_modules`, your GitHub Action can be relea
 with less time for pushes during action development and pulls during CI execution.
 
 > This Action written in TypeScript has been compiled by itself and released.
-> [See pre-built commit](https://github.com/satackey/push-js-action/tree/release-master)
+> [See pre-built commit](https://github.com/jpribyl/push-js-action/tree/release-master)
 
 ### Docker container action
 
 This action builds an image from your Dockerfile, and pushes it to the Docker registry,
-and rewrites `action.yml#rans.image` by pushed tag.
+and rewrites `action.yml#runs.image` with the pushed tag.
 
 The job just pulls Docker image when using the action, and there's no time to build the Dockerfile.
 
@@ -36,7 +36,7 @@ The description `action.yml` can be read as `action.yaml`.
 #### Example (Step only)
 
 ```yaml
-- uses: satackey/push-prebuilt-action@v0.1
+- uses: jpribyl/push-prebuilt-action@v0.2
   with:
     push-branch: release-master
 ```
@@ -111,7 +111,7 @@ The artifacts must be in the dist/ directory and entrypoint must be dist/index.j
 #### Example (step only)
 
 ```yaml
-- uses: satackey/push-prebuilt-action@v0.1
+- uses: jpribyl/push-prebuilt-action@v0.2
   with:
     push-branch: release-<your_branch_name>
     docker-registry: docker.io
@@ -221,19 +221,19 @@ jobs:
 
     steps:
       - name: Setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Output branch name
         id: name
         run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
 
       - name: Push
-        uses: satackey/push-prebuilt-action@v0.1
+        uses: jpribyl/push-prebuilt-action@v0.2
         with:
           push-branch: release-${{ steps.name.outputs.branch }}
           # [optional] The commit can be tagged.
@@ -260,14 +260,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Output branch name
         id: name
         run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
 
       - name: Push
-        uses: satackey/push-prebuilt-action@v0.1
+        uses: jpribyl/push-prebuilt-action@v0.2
         with:
           push-branch: release-${{ steps.name.outputs.branch }}
           # [optional] The commit can be tagged.

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,6 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   # to compile self
   main: ts-dist/main.js

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/child-process-promise": "^2.2.1",
     "@types/jest": "^26.0.15",
     "@types/js-yaml": "^3.12.5",
-    "@types/node": "^14.14.9",
+    "@types/node": "^20.11.17",
     "@types/string-format": "^2.0.0",
     "@vercel/ncc": "^0.34.0",
     "child-process-promise": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "js-yaml": "^3.13.1",
     "rimraf": "^3.0.2",
     "string-format": "^2.0.0",
-    "ttypescript": "^1.5.13",
+    "ttypescript": "^1.5.15",
     "typescript-is": "^0.19.0"
   },
   "devDependencies": {

--- a/src/ActionConfig.ts
+++ b/src/ActionConfig.ts
@@ -18,7 +18,7 @@ export interface ActionConfig {
     };
   };
   runs: {
-    using: "docker" | "node16";
+    using: "docker" | "node20";
     [key: string]: any;
   };
   branding?: {
@@ -59,7 +59,7 @@ export function assertIsDockerActionConfig(
 
 export interface JavaScriptActionConfig extends ActionConfig {
   runs: {
-    using: "node16";
+    using: "node20";
     main: string;
     pre?: string;
     "pre-if"?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,10 +645,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
-"@types/node@^14.14.9":
-  version "14.18.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
-  integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
+"@types/node@^20.11.17":
+  version "20.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.17.tgz#cdd642d0e62ef3a861f88ddbc2b61e32578a9292"
+  integrity sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3732,6 +3734,11 @@ typescript-is@^0.19.0:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,10 +3662,10 @@ tsutils@^3.17.1:
   dependencies:
     tslib "^1.8.1"
 
-ttypescript@^1.5.13:
-  version "1.5.13"
-  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.13.tgz#c3bcb760599fe49157d30c5d5895a0023cbb7f30"
-  integrity sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==
+ttypescript@^1.5.15:
+  version "1.5.15"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.15.tgz#e45550ad69289d06d3bc3fd4a3c87e7c1ef3eba7"
+  integrity sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==
   dependencies:
     resolve ">=1.9.0"
 


### PR DESCRIPTION
Update runtime to Node v20, including types package, as well as Node version used in Workflow.